### PR TITLE
It file basename, not path

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -265,5 +265,5 @@ Route::get('share', function() {
     $permission->setRole('reader');
     $permission->setType('anyone');
     $permission->setAllowFileDiscovery(false);
-    $permissions = $service->permissions->create($file['path'], $permission);
+    $permissions = $service->permissions->create($file['basename'], $permission);
 });


### PR DESCRIPTION
It file basename, not path, case like:

1DlEl4nDgEn0GEGJNJKr_XhVnOR-dPT7R/1j2jCedo6xJkV66X0qEU2RmgxAWlx_HMY

That is: file - 1j2jCedo6xJkV66X0qEU2RmgxAWlx_HMY, directory - 1DlEl4nDgEn0GEGJNJKr_XhVnOR-dPT7R

if we fill in path, it gonna squawk ```File not found```, basename work